### PR TITLE
Add Support for line feed code `CRLF`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,7 +19,6 @@ where
     let line_pattern_crlf = "---\r\n";
 
     if let Some(slice) = text.strip_prefix(line_pattern_lf) {
-        //let slice = &text[line_pattern_lf.len()..];
         let index_of_ending_line = slice
             .find(line_pattern_lf)
             .ok_or(Error::MissingEndingLine)?;
@@ -27,7 +26,6 @@ where
         let body = &slice[(index_of_ending_line + line_pattern_lf.len())..];
         Ok(ParsedData { body, headers })
     } else if let Some(slice) = text.strip_prefix(line_pattern_crlf) {
-        //let slice = &text[line_pattern_crlf.len()..];
         let index_of_ending_line = slice
             .find(line_pattern_crlf)
             .ok_or(Error::MissingEndingLine)?;


### PR DESCRIPTION
# About
Made it possible to parse both CRLF and LF line feed codes in front matter.
